### PR TITLE
Updates to support docker compose and .NET 6.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     container_name: nginxalbumviewer
     image: nginxalbumviewer
     build:
-      context: ./nginx
-      dockerfile: Dockerfile
+      context: ./
+      dockerfile: nginx/Dockerfile
     # volumes:.
     #   - ./dist:/usr/share/nginx/html
     ports:
@@ -28,8 +28,6 @@ services:
       dockerfile: Dockerfile
  #   volumes:
  #     - ./src/AlbumViewerNetCore:/var/www/albumviewer
-    ports:
-     - "5000:5000"
     networks:
       - app-network
  

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -3,8 +3,8 @@ FROM nginx:alpine
 MAINTAINER Rick Strahl
 
 # Copy custom nginx config
-COPY ./nginx.conf /etc/nginx/nginx.conf
-COPY ./wwwroot /usr/share/nginx/html
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY src/AlbumViewerNetCore/wwwroot /usr/share/nginx/html
 
 EXPOSE 80 443
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -54,6 +54,6 @@ http {
          
     upstream dotnet {
         zone dotnet 64k;
-        server 127.0.0.1:5000;
+        server westwindalbumviewer:5000;
     }
 }

--- a/src/AlbumViewerNetCore/Dockerfile
+++ b/src/AlbumViewerNetCore/Dockerfile
@@ -1,17 +1,17 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/aspnet:latest
 
 MAINTAINER Rick Strahl
 
-ENV ASPNETCORE_URLS=http://*:80
+ENV ASPNETCORE_URLS=http://*:5000
 ENV ASPNETCORE_ENVIRONMENT=Production
 
 # Allow 1433 for SQL Server Access
-EXPOSE 1433
+#EXPOSE 1433
 
 WORKDIR /var/www/albumviewer
 
 # copy publish folder contents to web root
-COPY ./bin/Release/netcoreapp3.1/publish .
+COPY ./bin/Release/net6.0/publish .
 
 # Run out of Publish Folder
 CMD ["/bin/sh", "-c", "dotnet 'AlbumViewerNetCore.dll'"]


### PR DESCRIPTION
This PR adds changes I had to make to get this working against .NET 6.0 and current 'docker compose'.

Changes were:

*docker-compose.yml* - changed the context to one level lower, since its dockerfile could not reference the wwwroot contents in a parent directory. Also stopped exposing port 5000, since nginx only needs to talk to that port via the bridge network.
*nginx/Dockerfile* - changed the relative paths to handle the new context. I was not able to update the 'COPY wwwroot' statement to refer to a parent directory ("../AlbumViewer...")
*nginx.conf* - Changed the upstream server to use the bridge network relative name, as this line was causing nginx to try to access port 5000 on the nginx container (rather than the westwindalbumviewer container).
*AlbumViewerNetCore/Dockerfile" - Moved to latest ASP.Net image (including related release path), and stopped remapping the API server to 80 since this is internal only.
