### PR TITLE
use correct framework

### DIFF
--- a/src/AlbumViewerAngular/AlbumViewerAngular (content-only).csproj
+++ b/src/AlbumViewerAngular/AlbumViewerAngular (content-only).csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net80</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         
         <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
         <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>

--- a/src/AlbumViewerNetCore/Dockerfile
+++ b/src/AlbumViewerNetCore/Dockerfile
@@ -11,7 +11,7 @@ EXPOSE 1433
 WORKDIR /var/www/albumviewer
 
 # copy publish folder contents to web root
-COPY ./bin/Release/net80/publish .
+COPY ./bin/Release/net8.0/publish .
 
 # Run out of Publish Folder
 CMD ["/bin/sh", "-c", "dotnet 'AlbumViewerNetCore.dll'"]


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks